### PR TITLE
Change how ban api-method gets usernames

### DIFF
--- a/FindThoseBans.meta.js
+++ b/FindThoseBans.meta.js
@@ -1,3 +1,3 @@
 // ==UserScript==
-// @version 0.3.92
+// @version 0.3.93
 // ==/UserScript==

--- a/FindThoseBans.user.js
+++ b/FindThoseBans.user.js
@@ -2,7 +2,7 @@
 // @name         Find Those Bans
 // @author       Sighery
 // @description  Finds who is suspended and adds it to the blacklist and whitelist page
-// @version      0.3.92
+// @version      0.3.93
 // @icon         https://raw.githubusercontent.com/Sighery/Scripts/master/favicon.ico
 // @downloadURL  https://www.github.com/Sighery/Scripts/raw/master/FindThoseBans.user.js
 // @updateURL    https://www.github.com/Sighery/Scripts/raw/master/FindThoseBans.meta.js
@@ -38,7 +38,8 @@ GM_xmlhttpRequest({
 		console.log("isup request successful");
 
 		for (var i = 0; i < rows.length; i++) {
-			api_request(rows[i].getElementsByClassName("table__column__heading")[0].textContent.trim(), i);
+			var userLink = rows[i].getElementsByClassName("table__column__heading")[0].getAttribute("href");
+			api_request(userLink.substring(userLink.lastIndexOf("/")+1).trim(), i);
 		}
 	}
 });


### PR DESCRIPTION
So in trying to change how SGT-frog handled tagging, I remembered _why_ I did what I did. There are a lot of edge cases when applying those just "next to" the element on all pages.

So rather than continue trying to patch all of those (they just kept popping up..), I thought it might just be easier to alter how your script works a bit instead.
I've changed your script to pull the user name from the href attribute (similar to your `manual_request` method, but it substrings the username out). This way, regardless of what _any_ script does, you'll be sure to get a clean format you can use.

_Sidenote: I also upped the version since the script changed, but you can alter that if not desired._